### PR TITLE
Fix typos

### DIFF
--- a/PtpWebcamDalPlugin/PtpWebcamDevice.h
+++ b/PtpWebcamDalPlugin/PtpWebcamDevice.h
@@ -10,7 +10,7 @@
 
 #import "PtpWebcamPlugin.h"
 
-#import <CoreMediaIo/CMIOHardwarePlugIn.h>
+#import <CoreMediaIO/CMIOHardwarePlugIn.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/PtpWebcamDalPlugin/PtpWebcamObject.h
+++ b/PtpWebcamDalPlugin/PtpWebcamObject.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <CoreMediaIo/CMIOHardwarePlugIn.h>
+#import <CoreMediaIO/CMIOHardwarePlugIn.h>
 
 #include <stdbool.h>
 

--- a/PtpWebcamDalPlugin/PtpWebcamPlugin.h
+++ b/PtpWebcamDalPlugin/PtpWebcamPlugin.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <CoreMediaIo/CMIOHardwarePlugIn.h>
+#import <CoreMediaIO/CMIOHardwarePlugIn.h>
 #import <ImageCaptureCore/ICDeviceBrowser.h>
 
 #import "PtpWebcamObject.h"

--- a/PtpWebcamDalPlugin/PtpWebcamPluginInterface.m
+++ b/PtpWebcamDalPlugin/PtpWebcamPluginInterface.m
@@ -14,7 +14,7 @@ break command add -s python -o "return any('SafeGetElement' in f.name for f in f
 
 #import <Foundation/Foundation.h>
 
-#import <CoreMediaIo/CMIOHardwarePlugIn.h>
+#import <CoreMediaIO/CMIOHardwarePlugIn.h>
 
 #import "PtpWebcamPlugin.h"
 #import "PtpWebcamDevice.h"

--- a/PtpWebcamDalPlugin/PtpWebcamPtpDevice.h
+++ b/PtpWebcamDalPlugin/PtpWebcamPtpDevice.h
@@ -10,7 +10,7 @@
 
 #import "PtpWebcamPlugin.h"
 
-#import <CoreMediaIo/CMIOHardwarePlugIn.h>
+#import <CoreMediaIO/CMIOHardwarePlugIn.h>
 #import "PtpCamera.h"
 
 

--- a/PtpWebcamDalPlugin/PtpWebcamStream.h
+++ b/PtpWebcamDalPlugin/PtpWebcamStream.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <CoreMediaIo/CMIOHardwarePlugIn.h>
+#import <CoreMediaIO/CMIOHardwarePlugIn.h>
 
 #import "PtpWebcamObject.h"
 

--- a/PtpWebcamDalPlugin/PtpWebcamXpcDevice.h
+++ b/PtpWebcamDalPlugin/PtpWebcamXpcDevice.h
@@ -8,7 +8,7 @@
 
 #import "PtpWebcamDevice.h"
 
-#import <CoreMediaIo/CMIOHardwarePlugIn.h>
+#import <CoreMediaIO/CMIOHardwarePlugIn.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
Xcode 12 throws errors that `CoreMediaIo` does not exist. Looks to be a typo, should be `CoreMediaIO`. Not sure how it compiled earlier -- maybe the framework name was previously not case-sensitive? Or compiled on a case-insensitive file system?